### PR TITLE
Update vueSignature.vue  for multiple sing pad in single page

### DIFF
--- a/src/components/vueSignature.vue
+++ b/src/components/vueSignature.vue
@@ -69,7 +69,7 @@ export default {
 	},
 	created() {
 		var _this = this;
-		this.uid = "canvas" + _this._uid
+		this.uid = "canvas" + Math.random();
 		var sigOptions = Object.keys(_this.sigOption);
 		for (var item of sigOptions) {
 			_this.option[item] = _this.sigOption[item]


### PR DESCRIPTION
When Using 2 or more sign pad in same page the ref not pointing to correct pad due to the canvaid is undifined , added random uid so that it works fine